### PR TITLE
fix(alc): prevent tokio oneshot panic in SenderSink::poll_flush during teardown

### DIFF
--- a/aggligator/src/alc/sender.rs
+++ b/aggligator/src/alc/sender.rs
@@ -227,8 +227,10 @@ impl Sink<Bytes> for SenderSink {
         }
 
         let flushed_rx = this.flushed_rx.as_mut().unwrap();
-        ready!(flushed_rx.poll_unpin(cx)).map_err(|_| this.error_rx.borrow().clone())?;
+        let res = ready!(flushed_rx.poll_unpin(cx));
+        
         this.flushed_rx = None;
+        res.map_err(|_| this.error_rx.borrow().clone())?;
 
         Poll::Ready(Ok(()))
     }

--- a/aggligator/src/alc/sender.rs
+++ b/aggligator/src/alc/sender.rs
@@ -228,11 +228,9 @@ impl Sink<Bytes> for SenderSink {
 
         let flushed_rx = this.flushed_rx.as_mut().unwrap();
         let res = ready!(flushed_rx.poll_unpin(cx));
-        
         this.flushed_rx = None;
-        res.map_err(|_| this.error_rx.borrow().clone())?;
 
-        Poll::Ready(Ok(()))
+        Poll::Ready(res.map_err(|_| this.error_rx.borrow().clone()))
     }
 
     fn poll_close(self: Pin<&mut Self>, cx: &mut Context) -> Poll<Result<(), Self::Error>> {


### PR DESCRIPTION
### What does this PR do?
This PR fixes a bug in `SenderSink::poll_flush` where an abrupt connection closure could cause the application to panic with `called after complete`.

### The Bug
During an abrupt connection drop or rapid teardown, the `flushed_rx` oneshot receiver in `SenderSink::poll_flush` can resolve with an error (due to the sender being dropped). 

In the original code:
```rust
ready!(flushed_rx.poll_unpin(cx)).map_err(|_| this.error_rx.borrow().clone())?;
this.flushed_rx = None;
```
If `poll_unpin` returns an `Err`, the `?` operator forces an early return. The assignment `this.flushed_rx = None;` is skipped. 

Because `aggligator` (and user code) often calls `poll_flush` or `poll_close` multiple times during shutdown sequences, the next call sees that `this.flushed_rx` is still `Some(...)`. It attempts to poll the `oneshot::Receiver` again, which inherently violates Tokio's contract and causes a panic:

```text
thread 'tokio-rt-worker' panicked at /.../tokio-1.51.1/src/sync/oneshot.rs:1289:13:
called after complete
```

### The Fix
This PR ensures that `this.flushed_rx` is unconditionally set to `None` *before* evaluating the `Result` and potentially returning early via `?`.

```rust
let res = ready!(flushed_rx.poll_unpin(cx));
this.flushed_rx = None;
res.map_err(|_| this.error_rx.borrow().clone())?;
```

This guarantees the oneshot receiver is never polled twice, cleanly returning the connection error back up the stack.